### PR TITLE
Parse headings before transitions to allow forces heading ending with "TO:"

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,15 @@ Hello
             } catch (e) {
                 defaultConfig = {
                     print_headers: true,
-                    double_space_between_scenes: true
+                    print_actions: true,
+                    print_dialogues: true,
+                    print_notes: true,
+                    print_sections: true,
+                    print_synopsis: true,
+                    each_scene_on_new_page: true,
+                    double_space_between_scenes: true,
+                    use_dual_dialogue: true,
+                    merge_multiple_empty_lines: true
                 };
             }
 

--- a/parser.js
+++ b/parser.js
@@ -145,19 +145,6 @@ parser.parse = function(original_script, cfg) {
         if (state === "normal") {
             if (token.text.match(regex.line_break)) {
                 token_category = "none";
-            } else if (token.text.match(regex.centered)) {
-                token.type = "centered";
-                token.text = token.text.replace(/>|</g, "").trim();
-            } else if (token.text.match(regex.transition)) {
-                token.text = token.text.replace(/> ?/, "");
-                token.type = "transition";
-            } else if (match = token.text.match(regex.synopsis)) {
-                token.text = match[1];
-                token.type = token.text ? "synopsis" : "separator";
-            } else if (match = token.text.match(regex.section)) {
-                token.level = match[1].length;
-                token.text = match[2];
-                token.type = "section";
             } else if (token.text.match(regex.scene_heading)) {
                 token.text = token.text.replace(/^\./, "");
                 if (cfg.each_scene_on_new_page && scene_number !== 1) {
@@ -176,6 +163,19 @@ parser.parse = function(original_script, cfg) {
                     token.number = match[1];
                 }
                 scene_number++;
+            } else if (token.text.match(regex.centered)) {
+                token.type = "centered";
+                token.text = token.text.replace(/>|</g, "").trim();
+            } else if (token.text.match(regex.transition)) {
+                token.text = token.text.replace(/> ?/, "");
+                token.type = "transition";
+            } else if (match = token.text.match(regex.synopsis)) {
+                token.text = match[1];
+                token.type = token.text ? "synopsis" : "separator";
+            } else if (match = token.text.match(regex.section)) {
+                token.level = match[1].length;
+                token.text = match[2];
+                token.type = "section";
             } else if (token.text.match(regex.page_break)) {
                 token.text = "";
                 token.type = "page_break";

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -148,6 +148,11 @@ describe('Parser', function() {
             testHelper.verifyTokenTypes(result.tokens, ['transition']);
         });
 
+        it('Forced heading takes priority over default transitions', function() {
+            script = '.CUT TO:';
+            result = parser.parse(script, config);
+            testHelper.verifyTokenTypes(result.tokens, ['scene_heading']);
+        });
     });
 
     describe('Newline', function() {


### PR DESCRIPTION
Bug:

```
.THROUGH SCOPE:

The speedboat launches directly into the Earth's sun.

.BACK TO:

Max smirks. He begins disassembling his rifle.

CUT TO
```

is parsed as:

* heading
* action
* *transition* -> should be *heading*
* action
* transition