### PR TITLE
Retain whitespace characters

### DIFF
--- a/dist/aw-parser.amd.js
+++ b/dist/aw-parser.amd.js
@@ -272,7 +272,7 @@ parser.parse = function(original_script, cfg) {
 
     var create_token = function(text, cursor, line) {
         return h.create_token({
-            text: text.trim(),
+            text: text,
             start: cursor,
             end: cursor + text.length - 1 + new_line_length,
             line: line
@@ -358,13 +358,13 @@ parser.parse = function(original_script, cfg) {
             if (regex.title_page.test(token.text)) {
                 var index = token.text.indexOf(":");
                 token.type = token.text.substr(0, index).toLowerCase();
-                token.text = token.text.substr(index + 1);
+                token.text = token.text.substr(index + 1).trim();
                 last_title_page_token = token;
                 result.title_page.push(token);
                 title_page_started = true;
                 continue;
             } else if (title_page_started) {
-                last_title_page_token.text += (last_title_page_token.text ? "\n" : "") + token.text;
+                last_title_page_token.text += (last_title_page_token.text ? "\n" : "") + token.text.trim();
                 continue;
             }
         }
@@ -456,7 +456,7 @@ parser.parse = function(original_script, cfg) {
             if (token.text && token.text[0] === "~") {
                 token.text = "*" + token.text.substr(1) + "*";
             }
-            token.text = token.text.trim();
+            token.text = token.is("action") ? token.text : token.text.trim();
             result.tokens.push(token);
         }
 

--- a/parser.js
+++ b/parser.js
@@ -45,7 +45,7 @@ parser.parse = function(original_script, cfg) {
 
     var create_token = function(text, cursor, line) {
         return h.create_token({
-            text: text.trim(),
+            text: text,
             start: cursor,
             end: cursor + text.length - 1 + new_line_length,
             line: line
@@ -131,13 +131,13 @@ parser.parse = function(original_script, cfg) {
             if (regex.title_page.test(token.text)) {
                 var index = token.text.indexOf(":");
                 token.type = token.text.substr(0, index).toLowerCase();
-                token.text = token.text.substr(index + 1);
+                token.text = token.text.substr(index + 1).trim();
                 last_title_page_token = token;
                 result.title_page.push(token);
                 title_page_started = true;
                 continue;
             } else if (title_page_started) {
-                last_title_page_token.text += (last_title_page_token.text ? "\n" : "") + token.text;
+                last_title_page_token.text += (last_title_page_token.text ? "\n" : "") + token.text.trim();
                 continue;
             }
         }
@@ -229,7 +229,7 @@ parser.parse = function(original_script, cfg) {
             if (token.text && token.text[0] === "~") {
                 token.text = "*" + token.text.substr(1) + "*";
             }
-            token.text = token.text.trim();
+            token.text = token.is("action") ? token.text : token.text.trim();
             result.tokens.push(token);
         }
 

--- a/test/data/sample.tokens.json
+++ b/test/data/sample.tokens.json
@@ -8,7 +8,7 @@
       "end": 60
     },
     {
-      "text": " written by",
+      "text": "written by",
       "type": "credit",
       "line": 8,
       "start": 94,
@@ -22,7 +22,7 @@
       "end": 121
     },
     {
-      "text": " script based on...",
+      "text": "script based on...",
       "type": "source",
       "line": 12,
       "start": 158,
@@ -36,7 +36,7 @@
       "end": 192
     },
     {
-      "text": " 01/12/2010",
+      "text": "01/12/2010",
       "type": "date",
       "line": 16,
       "start": 237,
@@ -50,7 +50,7 @@
       "end": 262
     },
     {
-      "text": " Licence info",
+      "text": "Licence info",
       "type": "copyright",
       "line": 20,
       "start": 313,
@@ -406,7 +406,7 @@
       "end": 2044
     },
     {
-      "text": "What the f\\*ck! Escape\\_escape\\*escape.",
+      "text": "What the f\\*ck! Escape\\_escape\\*escape. ",
       "type": "action",
       "line": 72,
       "start": 2045,

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -155,6 +155,46 @@ describe('Parser', function() {
         });
     });
 
+    describe('Retain whitespace', function() {
+
+        beforeEach(function() {
+            config = testHelper.getConfigWith(true);
+        });
+
+        it('Retains whitespace on action elements', function() {
+            var lines = [
+                'Action line.',
+                '\tAction line with tabs\t',
+                '  Action line with spaces  '
+            ];
+            script = lines.join('\n');
+            result = parser.parse(script, config);
+            testHelper.verifyTokenTypes(result.tokens, ['action', 'action', 'action']);
+
+            chai.assert.strictEqual(result.tokens[0].text, lines[0]);
+            chai.assert.strictEqual(result.tokens[1].text, lines[1]);
+            chai.assert.strictEqual(result.tokens[2].text, lines[2]);
+        });
+
+        it('Does not retain whitespace on non-action elements', function() {
+            var lines = [
+                'HERO',
+                'Dialogue line.',
+                '\tDialogue line with tabs\t',
+                '  Dialogue line with spaces  '
+            ];
+            script = lines.join('\n');
+            result = parser.parse(script, config);
+            testHelper.verifyTokenTypes(result.tokens, ['character', 'dialogue', 'dialogue', 'dialogue']);
+
+            chai.assert.strictEqual(result.tokens[0].text, lines[0].trim());
+            chai.assert.strictEqual(result.tokens[1].text, lines[1].trim());
+            chai.assert.strictEqual(result.tokens[2].text, lines[2].trim());
+            chai.assert.strictEqual(result.tokens[3].text, lines[3].trim());
+        });
+
+    });
+
     describe('Newline', function() {
 
         var crlf, cr, lf, config;


### PR DESCRIPTION
As per spec: https://fountain.io/syntax#section-action
white characters should be retained in action blocks.

This also fixes title page tokens not being trimmed
correctly.